### PR TITLE
feat: behave like official vscode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Integrate [AutoCorrect](https://github.com/huacnlee/autocorrect) with ESLint.
 
+The plugin requires eslint >= 9.
+
 ## Usage
 
 Install `eslint-plugin-autocorrect` using your package manager, and add this to `eslint.config.js`:
@@ -24,4 +26,25 @@ export default defineConfig([
 
 The plugin provides a single rule `autocorrect/issue` to report issues found by AutoCorrect, and auto-fixes.
 
-The plugin requires eslint >= 9.
+### Options
+
+The `autocorrect/issue` rule accepts an optional object with the following properties:
+
+- `messageStyle`: Configures the style of the error message.
+    - `"default"` (default): Shows "Correct it" as the message.
+    - `"correct"`: Shows the corrected text as the message.
+
+Example configuration:
+
+```js
+export default defineConfig([
+  {
+    plugins: {
+      autocorrect,
+    },
+    rules: {
+      'autocorrect/issue': ['error', { messageStyle: 'correct' }],
+    },
+  },
+]);
+```

--- a/__tests__/rule.spec.ts
+++ b/__tests__/rule.spec.ts
@@ -52,3 +52,20 @@ it('should respect .autocorrectignore', () => tester.run('rule', correct, {
 
   invalid: [],
 }));
+
+it('should work w/ messageStyle option', () => tester.run('rule', correct, {
+  valid: [],
+  invalid: [{
+    filename: '.js',
+    code: 'console.log("Hello世界")',
+    options: [{ messageStyle: 'correct' }],
+    errors: [{ message: '"Hello 世界"' }],
+    output: 'console.log("Hello 世界")',
+  }, {
+    filename: '.js',
+    code: 'console.log("Hello世界")',
+    options: [{ messageStyle: 'default' }],
+    errors: [{ message: 'Correct it' }],
+    output: 'console.log("Hello 世界")',
+  }],
+}));

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -30,7 +30,7 @@ const rule = {
       const start = { line: line.l, column: line.c - 1 };
       const end = { line: line.l, column: line.c - 1 + line.old.length };
       ctx.report({
-        message: line.new, 
+        message: line.new,
         loc: { start, end },
         fix: f => f.replaceTextRange(
           [sourceCode.getIndexFromLoc(start), sourceCode.getIndexFromLoc(end)],

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -12,7 +12,17 @@ const rule = {
   meta: {
     type: 'layout',
     fixable: 'whitespace',
-    schema: [],
+    schema: [{
+      type: 'object',
+      properties: {
+        messageStyle: {
+          type: 'string',
+          enum: ['correct', 'default'],
+          default: 'correct',
+        },
+      },
+      additionalProperties: false,
+    }],
     docs: {
       recommended: true,
     },
@@ -24,13 +34,18 @@ const rule = {
       return {};
     if (ignorer.isIgnored(ctx.filename))
       return {};
+
+    const ruleOptions: any = ctx.options[0] || {};
+    const messageStyle = ruleOptions.messageStyle || 'new';
+
     const res = lintFor(sourceCode.getText(), ctx.filename);
 
     for (const line of res.lines) {
       const start = { line: line.l, column: line.c - 1 };
       const end = { line: line.l, column: line.c - 1 + line.old.length };
+
       ctx.report({
-        message: line.new,
+        message: messageStyle === 'correct' ? line.new : 'Correct it',
         loc: { start, end },
         fix: f => f.replaceTextRange(
           [sourceCode.getIndexFromLoc(start), sourceCode.getIndexFromLoc(end)],

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -13,9 +13,6 @@ const rule = {
     type: 'layout',
     fixable: 'whitespace',
     schema: [],
-    messages: {
-      issue: 'Correct it',
-    },
     docs: {
       recommended: true,
     },
@@ -33,7 +30,7 @@ const rule = {
       const start = { line: line.l, column: line.c - 1 };
       const end = { line: line.l, column: line.c - 1 + line.old.length };
       ctx.report({
-        messageId: 'issue',
+        message: line.new, 
         loc: { start, end },
         fix: f => f.replaceTextRange(
           [sourceCode.getIndexFromLoc(start), sourceCode.getIndexFromLoc(end)],


### PR DESCRIPTION
Make the error message look and read like those in official VS Code extensions.

<img width="385" alt="image" src="https://github.com/user-attachments/assets/62081bdc-c7c5-4a22-b5ea-02a365585f47" />
